### PR TITLE
fix: Update baseURL to GitHub Pages URL

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "https://jeonglab.bcm.edu/"
+baseURL = "https://hyunhwan-jeong.github.io/"
 locale = "en-us"
 title = "Jeong Lab | Baylor College of Medicine"
 theme = "paper"


### PR DESCRIPTION
Fixes 404 error by updating baseURL to https://hyunhwan-jeong.github.io/