### PR TITLE
fix: Add environment to deploy workflow

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -41,6 +41,8 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
Fix workflow by adding environment: github-pages as required by actions/deploy-pages@v4