### PR TITLE
fix: Dark mode hiring callout only applies in dark mode

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -45,7 +45,7 @@
 }
 
 /* Hiring callout dark mode */
-.hiring-callout {
+.dark .hiring-callout {
   background: #1f1f1f;
   border-left-color: #a08060;
 }


### PR DESCRIPTION
Wrap hiring callout dark mode CSS in .dark class so background is light by default and only turns dark when dark mode is enabled