### PR TITLE
Add dark theme support for DOI badge

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -83,6 +83,20 @@
   margin-left: 0.4rem;
 }
 
+.doi-badge:hover {
+  background: #d0e3fc;
+}
+
+/* DOI badge dark mode */
+.dark .doi-badge {
+  background: #2a2f3a;
+  color: #d1d5db;
+}
+
+.dark .doi-badge:hover {
+  background: #3a404d;
+}
+
 /* Research tool cards */
 .tool-grid {
   display: grid;


### PR DESCRIPTION
This pull request updates the styling for the DOI badge to improve its appearance in both light and dark modes, including adding hover effects for better user interaction.

Styling improvements for DOI badge:

* Added a hover effect to the `.doi-badge` class for better visual feedback.
* Introduced specific background and text color styles for `.doi-badge` in dark mode, including a distinct hover state.